### PR TITLE
feat: upgrade Go, move to iterations, simplify loops and add buffering to readers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.22.0'
+        go-version: '1.24.1'
 
     - name: lint
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.24.1'
+        go-version: '1.24.2'
 
     - name: lint
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/logan-bobo/wc-go
 
-go 1.22.0
+go 1.24.2

--- a/main.go
+++ b/main.go
@@ -31,11 +31,11 @@ func countChars(bytes []byte) int {
 	var charCount int
 
 	fileContent := string(bytes)
-	lines := strings.Split(fileContent, "\n")
+	lines := strings.SplitSeq(fileContent, "\n")
 
-	for _, line := range lines {
-		arrLine := strings.Split(line, "")
-		for i := 0; i < len(arrLine); i++ {
+	for line := range lines {
+		arrLine := strings.SplitSeq(line, "")
+		for range arrLine {
 			charCount++
 		}
 
@@ -62,13 +62,13 @@ func fileToBytes(fileName string) []byte {
 func stripTabAndSpaceFromLine(text string) []string {
 	var flatWords []string
 
-	words := strings.Split(text, " ")
-	for _, word := range words {
+	words := strings.SplitSeq(text, " ")
+	for word := range words {
 		tabInWord := strings.Contains(word, "	")
 		if tabInWord {
-			splitWords := strings.Split(word, "	")
+			splitWords := strings.SplitSeq(word, "	")
 
-			for _, splitWord := range splitWords {
+			for splitWord := range splitWords {
 				flatWords = append(flatWords, splitWord)
 			}
 		} else {
@@ -83,9 +83,9 @@ func countWords(bytes []byte) int {
 	var wordCount int
 
 	fileContent := string(bytes)
-	text := strings.Split(fileContent, "\n")
+	text := strings.SplitSeq(fileContent, "\n")
 
-	for _, line := range text {
+	for line := range text {
 		line = strings.TrimSpace(line)
 
 		if line != "" {

--- a/main_test.go
+++ b/main_test.go
@@ -8,25 +8,8 @@ import (
 
 const testFile string = "test.txt"
 
-func TestFileToBytes(t *testing.T) {
-	fileData := fileToBytes(testFile)
-	fileBytes, err := os.ReadFile(testFile)
-
-	if err != nil {
-		t.Error("Can not find test data")
-	}
-
-	equalBytes := reflect.DeepEqual(fileData, fileBytes)
-
-	if equalBytes != true {
-		t.Errorf("FileToBytes(%s), FAILED. Expected %s got %s \n", testFile, fileBytes, fileData)
-	} else {
-		t.Logf("FileToBytes(%s), PASSED.\n", testFile)
-	}
-}
-
 func TestByteCount(t *testing.T) {
-	fileBytes := fileToBytes(testFile)
+	fileBytes, _ := os.ReadFile(testFile)
 	byteCount := countBytes(fileBytes)
 	byteCountExpected := 342190
 
@@ -38,7 +21,7 @@ func TestByteCount(t *testing.T) {
 }
 
 func TestLineCount(t *testing.T) {
-	fileBytes := fileToBytes(testFile)
+	fileBytes, _ := os.ReadFile(testFile)
 	lineCount := countLines(fileBytes)
 	lineCountExpected := 7145
 
@@ -50,7 +33,7 @@ func TestLineCount(t *testing.T) {
 }
 
 func TestWordCount(t *testing.T) {
-	fileBytes := fileToBytes(testFile)
+	fileBytes, _ := os.ReadFile(testFile)
 	wordCount := countWords(fileBytes)
 	wordCountExpected := 58164
 
@@ -62,7 +45,7 @@ func TestWordCount(t *testing.T) {
 }
 
 func TestCharCount(t *testing.T) {
-	fileBytes := fileToBytes(testFile)
+	fileBytes, _ := os.ReadFile(testFile)
 	charCount := countChars(fileBytes)
 	charCountExpected := 339292
 


### PR DESCRIPTION
This PR:
- Upgrades Go
- Moves `Split` to `SplitSeq` as we want to be using iterators
- Makes use of `bufio` to buffer a file and stdin  line by line to reduce memory footprint